### PR TITLE
corba: manage links to Service instances in weak pointers and copy task name for logging during cleanup

### DIFF
--- a/rtt/transports/corba/ServiceI.cpp
+++ b/rtt/transports/corba/ServiceI.cpp
@@ -94,19 +94,19 @@ PortableServer::POA_ptr RTT_corba_CService_i::_default_POA()
 char * RTT_corba_CService_i::getName (
     void)
 {
-    return CORBA::string_dup( mservice->getName().c_str() );
+    return CORBA::string_dup( mservice.lock()->getName().c_str() );
 }
 
 char * RTT_corba_CService_i::getServiceDescription (
     void)
 {
-    return CORBA::string_dup( mservice->doc().c_str() );
+    return CORBA::string_dup( mservice.lock()->doc().c_str() );
 }
 
 ::RTT::corba::CService::CProviderNames * RTT_corba_CService_i::getProviderNames (
     void)
 {
-    Service::ProviderNames names = mservice->getProviderNames();
+    Service::ProviderNames names = mservice.lock()->getProviderNames();
     ::RTT::corba::CService::CProviderNames_var result = new ::RTT::corba::CService::CProviderNames();
     result->length( names.size() );
     for (unsigned int i=0; i != names.size(); ++i )
@@ -122,7 +122,7 @@ char * RTT_corba_CService_i::getServiceDescription (
     if ( svc == "this" )
         return _this();
 
-    Service::shared_ptr provider = mservice->getService(svc);
+    Service::shared_ptr provider = mservice.lock()->getService(svc);
     if ( !provider )
     	return RTT::corba::CService::_nil();
 
@@ -143,7 +143,7 @@ char * RTT_corba_CService_i::getServiceDescription (
 ::CORBA::Boolean RTT_corba_CService_i::hasService (
     const char * name)
 {
-    return mservice->hasService( name );
+    return mservice.lock()->hasService( name );
 }
 
 ::RTT::corba::CServiceDescription * RTT_corba_CService_i::getCServiceDescription (
@@ -168,7 +168,7 @@ char * RTT_corba_CService_i::getServiceDescription (
     d->attributes = attributes;
 
     // Child services
-    Service::ProviderNames providers = mservice->getProviderNames();
+    Service::ProviderNames providers = mservice.lock()->getProviderNames();
     d->children.length( providers.size() );
     d->children_descriptions.length( providers.size() );
     j = 0;
@@ -177,7 +177,7 @@ char * RTT_corba_CService_i::getServiceDescription (
         if (providers[i] == "this") continue;
 
         // omit PortObject services
-        if (mservice->getPort(providers[i])) continue;
+        if (mservice.lock()->getPort(providers[i])) continue;
 
         ::RTT::corba::CService_ptr provider = getService(providers[i].c_str());
         Servants::const_iterator it = mservs.find(providers[i]);

--- a/rtt/transports/corba/ServiceI.h
+++ b/rtt/transports/corba/ServiceI.h
@@ -93,7 +93,7 @@ class  RTT_corba_CService_i
 {
 protected:
     PortableServer::POA_var mpoa;
-    RTT::Service::shared_ptr mservice;
+    boost::weak_ptr<RTT::Service> mservice;
     // child services
     typedef std::map<std::string, std::pair<RTT::corba::CService_var,PortableServer::ServantBase_var> > Servants;
     Servants mservs;

--- a/rtt/transports/corba/TaskContextProxy.cpp
+++ b/rtt/transports/corba/TaskContextProxy.cpp
@@ -570,7 +570,7 @@ namespace RTT
         if (! force_remote)
         {
             for (TaskContextServer::ServerMap::iterator it = TaskContextServer::servers.begin(); it != TaskContextServer::servers.end(); ++it)
-                if ( it->second->server()->_is_equivalent( t ) ) {
+                if ( it->second.second->server()->_is_equivalent( t ) ) {
                     log(Debug) << "Local server found !" <<endlog();
                     return it->first;
                 }

--- a/rtt/transports/corba/TaskContextServer.hpp
+++ b/rtt/transports/corba/TaskContextServer.hpp
@@ -69,7 +69,7 @@ namespace RTT
         friend class OrbRunner;
         friend class TaskContextProxy;
 
-        typedef std::map<TaskContext*, TaskContextServer*> ServerMap;
+        typedef std::map<TaskContext*, std::pair<std::string, TaskContextServer*> > ServerMap;
         static ServerMap servers;
         static base::ActivityInterface* orbrunner;
         static bool is_shutdown;


### PR DESCRIPTION
This patch is required to fix segfaults in connection with snrkiwi/ocl#1.

The CORBA layer should not delay the destruction of Service instances once the owning TaskContext gets destroyed. Accessing a destroyed service instance through CORBA would result in a bad_weak_ptr exception.

For the case the TaskContext is destroyed before the TaskContextServer we need to make a copy of the task name for logging in the destructor. There is no mechanism in RTT that guarantees that a server is destroyed before the actual TaskContext.

CC: @psoetens, @smits
