### PR TITLE
Revert locking in Activitiy::trigger() and ExecutionEngine::process()

### DIFF
--- a/rtt/Activity.cpp
+++ b/rtt/Activity.cpp
@@ -98,10 +98,6 @@ namespace RTT
     Activity::~Activity()
     {
         stop();
-
-        // We need to join the activity's thread before destruction as the thread function might still
-        // access member variables. Activity::stop() does not guarantuee to stop the underlying thread.
-        terminate();
     }
 
     os::ThreadInterface* Activity::thread() {
@@ -141,10 +137,7 @@ namespace RTT
         if ( ! Thread::isActive() )
             return false;
         //a trigger is always allowed when active
-        {
-            os::MutexLock lock(msg_lock);
-            msg_cond.broadcast();
-        }
+        msg_cond.broadcast();
         Thread::start();
         return true;
     }
@@ -160,6 +153,7 @@ namespace RTT
             return false;
         }
         mtimeout = true;
+        msg_cond.broadcast();
         Thread::start();
         return true;
     }

--- a/rtt/Activity.cpp
+++ b/rtt/Activity.cpp
@@ -98,6 +98,10 @@ namespace RTT
     Activity::~Activity()
     {
         stop();
+
+        // We need to join the activity's thread before destruction as the thread function might still
+        // access member variables. Activity::stop() does not guarantuee to stop the underlying thread.
+        terminate();
     }
 
     os::ThreadInterface* Activity::thread() {

--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -126,7 +126,6 @@ namespace RTT
             assert(foo);
             if ( foo->execute() == false ){
                 foo->unloaded();
-                os::MutexLock lock(msg_lock);
                 msg_cond.broadcast(); // required for waitForFunctions() (3rd party thread)
             } else {
                 f_queue->enqueue( foo );
@@ -233,16 +232,16 @@ namespace RTT
                 assert( com );
                 com->executeAndDispose();
             }
+            // there's no need to hold the lock during
+            // emptying the queue. But we must hold the
+            // lock once between excuteAndDispose and the
+            // broadcast to avoid the race condition in
+            // waitForMessages().
+            // This allows us to recurse into processMessages.
+            MutexLock locker( msg_lock );
         }
-
-        // there's no need to hold the lock during
-        // emptying the queue. But we must hold the
-        // lock once between excuteAndDispose and the
-        // broadcast to avoid the race condition in
-        // waitForMessages().
-        // This allows us to recurse into processMessages.
-        MutexLock locker( msg_lock );
-        msg_cond.broadcast(); // required for waitForMessages() (3rd party thread)
+        if ( com )
+            msg_cond.broadcast(); // required for waitForMessages() (3rd party thread)
     }
 
     bool ExecutionEngine::process( DisposableInterface* c )
@@ -259,10 +258,7 @@ namespace RTT
 
             bool result = mqueue->enqueue( c );
             this->getActivity()->trigger();
-            {
-                os::MutexLock lock(msg_lock);
-                msg_cond.broadcast(); // required for waitAndProcessMessages() (EE thread)
-            }
+            msg_cond.broadcast(); // required for waitAndProcessMessages() (EE thread)
             return result;
         }
         return false;

--- a/rtt/os/Thread.cpp
+++ b/rtt/os/Thread.cpp
@@ -626,6 +626,7 @@ namespace RTT {
             rtos_sem_signal(&sem);
 
             rtos_task_delete(&rtos_task); // this must join the thread.
+            active = false;
         }
 
         const char* Thread::getName() const

--- a/rtt/os/Thread.cpp
+++ b/rtt/os/Thread.cpp
@@ -626,7 +626,6 @@ namespace RTT {
             rtos_sem_signal(&sem);
 
             rtos_task_delete(&rtos_task); // this must join the thread.
-            active = false;
         }
 
         const char* Thread::getName() const


### PR DESCRIPTION
See https://github.com/psoetens/rtt/pull/9.

I discussed this with Peter and we could not explain why the locks have been introduced back in 2015. The blocking trigger call might have been caused by another bug, that has been fixed in the meantime, or the missing `terminate()` call in the Activity destructor. The latter has been re-added as a separate commit.