### PR TITLE
FileDescriptorActivity locking and robustness

### DIFF
--- a/rtt/extras/FileDescriptorActivity.cpp
+++ b/rtt/extras/FileDescriptorActivity.cpp
@@ -182,7 +182,7 @@ void FileDescriptorActivity::setTimeout_us(int timeout_us)
     }
 }
 void FileDescriptorActivity::watch(int fd)
-{ RTT::os::MutexLock lock(m_lock);
+{ RTT::os::MutexLock lock(m_fd_lock);
     if (fd < 0)
     {
         log(Error) << "negative file descriptor given to FileDescriptorActivity::watch" << endlog();
@@ -194,13 +194,13 @@ void FileDescriptorActivity::watch(int fd)
     triggerUpdateSets();
 }
 void FileDescriptorActivity::unwatch(int fd)
-{ RTT::os::MutexLock lock(m_lock);
+{ RTT::os::MutexLock lock(m_fd_lock);
     m_watched_fds.erase(fd);
     FD_CLR(fd, &m_fd_set);
     triggerUpdateSets();
 }
 void FileDescriptorActivity::clearAllWatches()
-{ RTT::os::MutexLock lock(m_lock);
+{ RTT::os::MutexLock lock(m_fd_lock);
     m_watched_fds.clear();
     FD_ZERO(&m_fd_set);
     triggerUpdateSets();
@@ -226,7 +226,7 @@ bool FileDescriptorActivity::hasError() const
 bool FileDescriptorActivity::hasTimeout() const
 { return m_has_timeout; }
 bool FileDescriptorActivity::isWatched(int fd) const
-{ RTT::os::MutexLock lock(m_lock);
+{ RTT::os::MutexLock lock(m_fd_lock);
     return FD_ISSET(fd, &m_fd_set); }
 
 bool FileDescriptorActivity::start()
@@ -308,7 +308,7 @@ void FileDescriptorActivity::loop()
     while(true)
     {
         int max_fd;
-        { RTT::os::MutexLock lock(m_lock);
+        { RTT::os::MutexLock lock(m_fd_lock);
             if (m_watched_fds.empty())
                 max_fd = pipe;
             else

--- a/rtt/extras/FileDescriptorActivity.cpp
+++ b/rtt/extras/FileDescriptorActivity.cpp
@@ -338,8 +338,15 @@ void FileDescriptorActivity::loop()
         m_has_error   = false;
         m_has_timeout = false;
         m_has_ioready = false;
-        if (ret == -1)
+        if (ret < 0)
         {
+            if (errno == EINTR)
+            {
+                // A signal was caught; see signal(7). We should not handle this
+                // here and simply continue waiting. Could be as trivial as
+                // a SIGWINCH (Window resize signal).
+                continue;
+            }
             log(Error) << "FileDescriptorActivity: error in select(), errno = " << errno << endlog();
             m_has_error = true;
         }

--- a/rtt/extras/FileDescriptorActivity.cpp
+++ b/rtt/extras/FileDescriptorActivity.cpp
@@ -325,7 +325,6 @@ void FileDescriptorActivity::loop()
         FD_SET(pipe, &m_fd_work);
 
         int ret = -1;
-        m_running = false;
         if (m_timeout_us == 0)
         {
             ret = select(max_fd + 1, &m_fd_work, NULL, NULL, NULL);
@@ -438,18 +437,13 @@ bool FileDescriptorActivity::breakLoop()
 
 void FileDescriptorActivity::step()
 {
-    m_running = true;
     if (runner != 0)
         runner->step();
-    m_running = false;
 }
 
 void FileDescriptorActivity::work(base::RunnableInterface::WorkReason reason) {
-    m_running = true;
     if (runner != 0)
         runner->work(reason);
-    m_running = false;
-
 }
 
 bool FileDescriptorActivity::stop()

--- a/rtt/extras/FileDescriptorActivity.cpp
+++ b/rtt/extras/FileDescriptorActivity.cpp
@@ -82,6 +82,7 @@ FileDescriptorActivity::FileDescriptorActivity(int priority, RunnableInterface* 
     , m_period(0)
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_has_ioready(false)
     , m_break_loop(false)
     , m_trigger(false)
     , m_update_sets(false)
@@ -107,6 +108,7 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Runn
     , m_period(0)
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_has_ioready(false)
     , m_break_loop(false)
     , m_trigger(false)
     , m_update_sets(false)
@@ -123,6 +125,7 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_period(period >= 0.0 ? period : 0.0)        // intended period
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_has_ioready(false)
     , m_break_loop(false)
     , m_trigger(false)
     , m_update_sets(false)
@@ -139,6 +142,7 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_period(period >= 0.0 ? period : 0.0)        // intended period
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_has_ioready(false)
     , m_break_loop(false)
     , m_trigger(false)
     , m_update_sets(false)
@@ -274,6 +278,7 @@ bool FileDescriptorActivity::trigger()
 { 
     if (isActive() ) {
         { RTT::os::MutexLock lock(m_command_mutex);
+            if (m_trigger) return true;
             m_trigger = true;
         }
         int unused; (void)unused;
@@ -287,7 +292,6 @@ bool FileDescriptorActivity::timeout()
 {
     return false;
 }
-
 
 struct fd_watch {
     int& fd;
@@ -319,7 +323,7 @@ void FileDescriptorActivity::loop()
         }
         FD_SET(pipe, &m_fd_work);
 
-        int ret;
+        int ret = -1;
         m_running = false;
         if (m_timeout_us == 0)
         {
@@ -327,7 +331,7 @@ void FileDescriptorActivity::loop()
         }
         else
         {
-			static const int USECS_PER_SEC = 1000000;
+            static const int USECS_PER_SEC = 1000000;
             timeval timeout = { m_timeout_us / USECS_PER_SEC,
                                 m_timeout_us % USECS_PER_SEC};
             ret = select(max_fd + 1, &m_fd_work, NULL, NULL, &timeout);
@@ -335,6 +339,7 @@ void FileDescriptorActivity::loop()
 
         m_has_error   = false;
         m_has_timeout = false;
+        m_has_ioready = false;
         if (ret == -1)
         {
             log(Error) << "FileDescriptorActivity: error in select(), errno = " << errno << endlog();
@@ -344,6 +349,11 @@ void FileDescriptorActivity::loop()
         {
 //            log(Error) << "FileDescriptorActivity: timeout in select()" << endlog();
             m_has_timeout = true;
+        }
+        else
+        {
+            // do not trigger an IOReady event if the only file descriptor that was active is the command pipe
+            m_has_ioready = !(ret == 1 && FD_ISSET(pipe, &m_fd_work));
         }
 
         // Empty all commands queued in the pipe
@@ -369,18 +379,15 @@ void FileDescriptorActivity::loop()
         }
 
         // We check the flags after the command queue was emptied as we could miss commands otherwise:
-        bool do_trigger = true;
-        bool user_trigger = false;
+        bool do_trigger = false;
         { RTT::os::MutexLock lock(m_command_mutex);
             // This section should be really fast to not block threads calling trigger(), breakLoop() or watch().
             if (m_trigger) {
-                do_trigger = true;
-                user_trigger = true;
                 m_trigger = false;
+                do_trigger = true;
             }
             if (m_update_sets) {
                 m_update_sets = false;
-                do_trigger = false;
             }
             if (m_break_loop) {
                 m_break_loop = false;
@@ -388,18 +395,20 @@ void FileDescriptorActivity::loop()
             }
         }
 
-        if (do_trigger)
+        // Execute activity...
+        if (m_has_timeout || m_has_ioready || do_trigger)
         {
             try
             {
                 m_running = true;
                 step();
-                if (m_has_timeout)
-                    work(RunnableInterface::TimeOut);
-                else if ( user_trigger )
+                if ( do_trigger )
                     work(RunnableInterface::Trigger);
-                else
+                if ( m_has_timeout )
+                    work(RunnableInterface::TimeOut);
+                if ( m_has_ioready )
                     work(RunnableInterface::IOReady);
+
                 m_running = false;
             }
             catch(...)
@@ -414,6 +423,7 @@ void FileDescriptorActivity::loop()
 bool FileDescriptorActivity::breakLoop()
 {
     { RTT::os::MutexLock lock(m_command_mutex);
+        if (m_break_loop) return true;
         m_break_loop = true;
     }
     int unused; (void)unused;

--- a/rtt/extras/FileDescriptorActivity.cpp
+++ b/rtt/extras/FileDescriptorActivity.cpp
@@ -82,10 +82,10 @@ FileDescriptorActivity::FileDescriptorActivity(int priority, RunnableInterface* 
     , m_period(0)
     , m_has_error(false)
     , m_has_timeout(false)
-    , m_break_loop(false)
-    , m_trigger(false)
-    , m_update_sets(false)
 {
+    oro_atomic_set(&m_break_loop, 0);
+    oro_atomic_set(&m_trigger, 0);
+    oro_atomic_set(&m_update_sets, 0);
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
     m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
@@ -107,10 +107,10 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Runn
     , m_period(0)
     , m_has_error(false)
     , m_has_timeout(false)
-    , m_break_loop(false)
-    , m_trigger(false)
-    , m_update_sets(false)
 {
+    oro_atomic_set(&m_break_loop, 0);
+    oro_atomic_set(&m_trigger, 0);
+    oro_atomic_set(&m_update_sets, 0);
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
     m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
@@ -123,10 +123,10 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_period(period >= 0.0 ? period : 0.0)        // intended period
     , m_has_error(false)
     , m_has_timeout(false)
-    , m_break_loop(false)
-    , m_trigger(false)
-    , m_update_sets(false)
 {
+    oro_atomic_set(&m_break_loop, 0);
+    oro_atomic_set(&m_trigger, 0);
+    oro_atomic_set(&m_update_sets, 0);
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
     m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
@@ -139,10 +139,10 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_period(period >= 0.0 ? period : 0.0)        // intended period
     , m_has_error(false)
     , m_has_timeout(false)
-    , m_break_loop(false)
-    , m_trigger(false)
-    , m_update_sets(false)
 {
+    oro_atomic_set(&m_break_loop, 0);
+    oro_atomic_set(&m_trigger, 0);
+    oro_atomic_set(&m_update_sets, 0);
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
     m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
@@ -211,9 +211,7 @@ void FileDescriptorActivity::clearAllWatches()
 }
 void FileDescriptorActivity::triggerUpdateSets()
 {
-    { RTT::os::MutexLock lock(m_command_mutex);
-        m_update_sets = true;
-    }
+    oro_atomic_inc(&m_update_sets);
     int unused; (void)unused;
     unused = write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
 }
@@ -255,9 +253,9 @@ bool FileDescriptorActivity::start()
 #endif
 
     // reset flags
-    m_break_loop = false;
-    m_trigger = false;
-    m_update_sets = false;
+    oro_atomic_set(&m_break_loop, 0);
+    oro_atomic_set(&m_trigger, 0);
+    oro_atomic_set(&m_update_sets, 0);
 
     if (!Activity::start())
     {
@@ -273,9 +271,7 @@ bool FileDescriptorActivity::start()
 bool FileDescriptorActivity::trigger()
 { 
     if (isActive() ) {
-        { RTT::os::MutexLock lock(m_command_mutex);
-            m_trigger = true;
-        }
+        oro_atomic_inc(&m_trigger);
         int unused; (void)unused;
         unused = write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
         return true;
@@ -371,21 +367,19 @@ void FileDescriptorActivity::loop()
         // We check the flags after the command queue was emptied as we could miss commands otherwise:
         bool do_trigger = true;
         bool user_trigger = false;
-        { RTT::os::MutexLock lock(m_command_mutex);
-            // This section should be really fast to not block threads calling trigger(), breakLoop() or watch().
-            if (m_trigger) {
-                do_trigger = true;
-                user_trigger = true;
-                m_trigger = false;
-            }
-            if (m_update_sets) {
-                m_update_sets = false;
-                do_trigger = false;
-            }
-            if (m_break_loop) {
-                m_break_loop = false;
-                break;
-            }
+
+        if (oro_atomic_read(&m_trigger) > 0) {
+            do_trigger = true;
+            user_trigger = true;
+            oro_atomic_set(&m_trigger, 0);
+        }
+        if (oro_atomic_read(&m_update_sets) > 0) {
+            oro_atomic_set(&m_update_sets, 0);
+            do_trigger = false;
+        }
+        if (oro_atomic_read(&m_break_loop) > 0) {
+            oro_atomic_set(&m_break_loop, 0);
+            break;
         }
 
         if (do_trigger)
@@ -413,9 +407,7 @@ void FileDescriptorActivity::loop()
 
 bool FileDescriptorActivity::breakLoop()
 {
-    { RTT::os::MutexLock lock(m_command_mutex);
-        m_break_loop = true;
-    }
+    oro_atomic_inc(&m_break_loop);
     int unused; (void)unused;
     unused = write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
     return true;

--- a/rtt/extras/FileDescriptorActivity.cpp
+++ b/rtt/extras/FileDescriptorActivity.cpp
@@ -83,9 +83,7 @@ FileDescriptorActivity::FileDescriptorActivity(int priority, RunnableInterface* 
     , m_has_error(false)
     , m_has_timeout(false)
 {
-    oro_atomic_set(&m_break_loop, 0);
-    oro_atomic_set(&m_trigger, 0);
-    oro_atomic_set(&m_update_sets, 0);
+    clearCommandFlags();
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
     m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
@@ -108,9 +106,7 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Runn
     , m_has_error(false)
     , m_has_timeout(false)
 {
-    oro_atomic_set(&m_break_loop, 0);
-    oro_atomic_set(&m_trigger, 0);
-    oro_atomic_set(&m_update_sets, 0);
+    clearCommandFlags();
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
     m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
@@ -124,9 +120,7 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_has_error(false)
     , m_has_timeout(false)
 {
-    oro_atomic_set(&m_break_loop, 0);
-    oro_atomic_set(&m_trigger, 0);
-    oro_atomic_set(&m_update_sets, 0);
+    clearCommandFlags();
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
     m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
@@ -140,9 +134,7 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_has_error(false)
     , m_has_timeout(false)
 {
-    oro_atomic_set(&m_break_loop, 0);
-    oro_atomic_set(&m_trigger, 0);
-    oro_atomic_set(&m_update_sets, 0);
+    clearCommandFlags();
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
     m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
@@ -215,6 +207,14 @@ void FileDescriptorActivity::triggerUpdateSets()
     int unused; (void)unused;
     unused = write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
 }
+
+void FileDescriptorActivity::clearCommandFlags()
+{
+    oro_atomic_set(&m_break_loop, 0);
+    oro_atomic_set(&m_trigger, 0);
+    oro_atomic_set(&m_update_sets, 0);
+}
+
 bool FileDescriptorActivity::isUpdated(int fd) const
 { return FD_ISSET(fd, &m_fd_work); }
 bool FileDescriptorActivity::hasError() const
@@ -252,10 +252,8 @@ bool FileDescriptorActivity::start()
     }
 #endif
 
-    // reset flags
-    oro_atomic_set(&m_break_loop, 0);
-    oro_atomic_set(&m_trigger, 0);
-    oro_atomic_set(&m_update_sets, 0);
+    // clear command flags
+    clearCommandFlags();
 
     if (!Activity::start())
     {

--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -110,7 +110,7 @@ namespace RTT { namespace extras {
         int  m_timeout_us;		//! timeout in microseconds
         Seconds m_period;		//! intended period
         /** Lock that protects the access to m_fd_set and m_watched_fds */
-        mutable RTT::os::Mutex m_lock;
+        mutable RTT::os::Mutex m_fd_lock;
         fd_set m_fd_set;
         fd_set m_fd_work;
         bool m_has_error;

--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -115,6 +115,7 @@ namespace RTT { namespace extras {
         fd_set m_fd_work;
         bool m_has_error;
         bool m_has_timeout;
+        bool m_has_ioready;
 
         static const char CMD_ANY_COMMAND = 0;
         RTT::os::Mutex m_command_mutex;

--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -117,10 +117,9 @@ namespace RTT { namespace extras {
         bool m_has_timeout;
 
         static const char CMD_ANY_COMMAND = 0;
-        RTT::os::Mutex m_command_mutex;
-        bool m_break_loop;
-        bool m_trigger;
-        bool m_update_sets;
+        mutable oro_atomic_t m_break_loop;
+        mutable oro_atomic_t m_trigger;
+        mutable oro_atomic_t m_update_sets;
 
         /** Internal method that makes sure loop() takes into account
          * modifications in the set of watched FDs

--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -126,6 +126,11 @@ namespace RTT { namespace extras {
          */
         void triggerUpdateSets();
 
+        /** Internal method to clear the command (trigger, break loop,
+         * update sets) flags.
+         */
+        void clearCommandFlags();
+
     public:
         /**
          * Create a FileDescriptorActivity with a given priority and base::RunnableInterface

--- a/tests/taskthread_fd_test.cpp
+++ b/tests/taskthread_fd_test.cpp
@@ -218,6 +218,9 @@ BOOST_AUTO_TEST_CASE(testFileDescriptor_Write )
 	mtask->unwatch(mcomp.fd[0]);
     BOOST_CHECK( mtask->isWatched(mcomp.fd[0]) == false );
 
+    // sleep to give the FileDescriptorActivity some time to update the internal file descriptor set
+    usleep(100000/10);
+
 	++ch;
 	rc = write(mcomp.fd[1], &ch, sizeof(ch));
 	if (1 != rc) std::cerr << "rc=" << rc << " errno=" << errno << ":" << strerror(errno) << std::endl;


### PR DESCRIPTION
This PR collects some patches to improve robustness of the `FileDescriptorActivity` and to avoid locks in `trigger()` and `breakLoop()` calls.

- Remove locks from `FileDescriptorActivity::trigger()`, `FileDescriptorActivity::breakLoop()` and `FileDescriptorActivity::triggerUpdateSets()` (contributed by @MagnaboscoL)
- Do not rearm the timeout timer if the previous cycle was due to a `trigger()` call. The previous implementation was waiting for the set timeout period after every interruption, which in theory could lead to the situation that the timeout cycle is never triggered if there is no activity on the file descriptor but the activity is constantly triggered due to operation calls or port callbacks.
- The bookkeeping of the `m_running` flag was buggy and `isRunning()` might have returned false even though the activity was still processing the `step()` function.
